### PR TITLE
GitHub #65: Fix duplicate keys in unnamed objects.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -254,7 +254,8 @@ check_PROGRAMS =  \
   asteria/test/bindings_math.test  \
   asteria/test/bindings_filesystem.test  \
   asteria/test/bindings_checksum.test  \
-  asteria/test/bindings_json.test
+  asteria/test/bindings_json.test  \
+  asteria/test/github_65.test
 
 TESTS = ${check_PROGRAMS}
 

--- a/asteria/src/runtime/air_node.cpp
+++ b/asteria/src/runtime/air_node.cpp
@@ -1124,6 +1124,7 @@ DCE_Result AIR_Node::optimize_dce()
         G_array array;
         array.resize(nelems);
         for(auto it = array.mut_rbegin(); it != array.rend(); ++it) {
+          // Write elements backwards.
           *it = ctx.stack().get_top().read();
           ctx.stack().pop();
         }
@@ -1142,7 +1143,8 @@ DCE_Result AIR_Node::optimize_dce()
         G_object object;
         object.reserve(keys.size());
         for(auto it = keys.rbegin(); it != keys.rend(); ++it) {
-          object.insert_or_assign(*it, ctx.stack().get_top().read());
+          // Use `try_emplace()` instead of `insert_or_assign()`. In case of duplicate keys, the last value takes precedence.
+          object.try_emplace(*it, ctx.stack().get_top().read());
           ctx.stack().pop();
         }
         // Push the object as a temporary.

--- a/asteria/test/github_65.cpp
+++ b/asteria/test/github_65.cpp
@@ -1,0 +1,27 @@
+// This file is part of Asteria.
+// Copyleft 2018, LH_Mouse. All wrongs reserved.
+
+#include "test_utilities.hpp"
+#include "../src/runtime/simple_script.hpp"
+#include "../src/runtime/global_context.hpp"
+
+using namespace Asteria;
+
+int main()
+  {
+    tinybuf_str cbuf;
+    cbuf.set_string(rocket::sref(
+      R"__(
+///////////////////////////////////////////////////////////////////////////////
+
+        var foo = 42;
+        var obj = { foo : foo, "foo" : "foo" };
+        assert obj.foo == "foo";
+
+///////////////////////////////////////////////////////////////////////////////
+      )__"), tinybuf::open_read);
+
+    Simple_Script code(cbuf, rocket::sref("my_file"));
+    Global_Context global;
+    code.execute(global);
+  }


### PR DESCRIPTION
Don't overwrite later-declared values with earlier-declared ones in case of duplicate keys in unnamed objects.

Signed-off-by: Liu Hao <lh_mouse@126.com>

This will close #65.
