### PR TITLE
Modify temporaries in place instead of involving local variables

### DIFF
--- a/asteria/src/runtime/air_node.cpp
+++ b/asteria/src/runtime/air_node.cpp
@@ -962,14 +962,10 @@ struct AIR_Traits_glvalue_to_prvalue
     AIR_Status
     execute(Executive_Context& ctx)
       {
-        // If the current reference is a constant or temporary,
-        // don't do anything.
+        // If the current reference is a constant or temporary, don't do anything.
         auto& self = ctx.stack().mut_back();
-        if(self.is_prvalue())
-          return air_status_next;
-
-        // Convert the result to a temporary.
-        self.mutate_into_temporary();
+        if(!self.is_prvalue())
+          self.mutate_into_temporary();
         return air_status_next;
       }
   };

--- a/asteria/src/runtime/reference.cpp
+++ b/asteria/src/runtime/reference.cpp
@@ -614,4 +614,19 @@ dereference_unset()
     }
   }
 
+Value&
+Reference::
+mutate_into_temporary()
+  {
+    // Return a mutable reference to the existent temporary value if any.
+    if(ROCKET_EXPECT(this->is_temporary() && this->m_mods.empty()))
+      return this->m_root.as<index_temporary>().val;
+
+    // Replace `*this` with a temporary.
+    S_temporary xref = { this->dereference_readonly() };
+    auto& r = this->m_root.emplace<index_temporary>(::std::move(xref));
+    this->m_mods.clear();
+    return r.val;
+  }
+
 }  // namespace asteria

--- a/asteria/src/runtime/reference.hpp
+++ b/asteria/src/runtime/reference.hpp
@@ -279,6 +279,9 @@ class Reference
     Value
     dereference_unset()
       const;
+
+    Value&
+    mutate_into_temporary();
   };
 
 inline


### PR DESCRIPTION
I observed ~6% execution time reduction with these commits.
