### PR TITLE
add <array> Prevent incomplete aggregate type

### DIFF
--- a/asteria/src/precompiled.hpp
+++ b/asteria/src/precompiled.hpp
@@ -39,6 +39,7 @@
 #include <type_traits>
 #include <functional>
 #include <algorithm>
+#include <array>
 
 #include <climits>
 #include <cmath>


### PR DESCRIPTION
Ubuntu20.04
gcc12
asteria/src/library/checksum.cpp
std::array<> val
aggregate type is incomplete