### PR TITLE
Disallow meaningless construction in syntax

### DIFF
--- a/asteria/compiler/statement_sequence.cpp
+++ b/asteria/compiler/statement_sequence.cpp
@@ -405,9 +405,9 @@ do_accept_expression_as_rvalue_opt(Token_Stream& tstrm)
   }
 
 opt<Statement::S_block>
-do_accept_block_opt(Token_Stream& tstrm, scope_flags scope)
+do_accept_statement_block_opt(Token_Stream& tstrm, scope_flags scope)
   {
-    // block ::=
+    // statement-block ::=
     //   "{" statement * "}"
     // statement-list ::=
     //   statement *
@@ -648,7 +648,7 @@ opt<Statement>
 do_accept_function_definition_opt(Token_Stream& tstrm)
   {
     // function-definition ::=
-    //   "func" identifier "(" parameter-list ? ")" block
+    //   "func" identifier "(" parameter-list ? ")" statement-block
     auto sloc = tstrm.next_sloc();
     auto qkwrd = do_accept_keyword_opt(tstrm, { keyword_func });
     if(!qkwrd)
@@ -675,7 +675,7 @@ do_accept_function_definition_opt(Token_Stream& tstrm)
                 compiler_status_closing_parenthesis_expected, tstrm.next_sloc(),
                 "[unmatched `(` at '$1']", op_sloc);
 
-    auto qbody = do_accept_block_opt(tstrm, scope_flags_plain);
+    auto qbody = do_accept_statement_block_opt(tstrm, scope_flags_plain);
     if(!qbody)
       throw Compiler_Error(Compiler_Error::M_status(),
                 compiler_status_open_brace_expected, tstrm.next_sloc());
@@ -1434,10 +1434,10 @@ opt<Statement>
 do_accept_statement_opt(Token_Stream& tstrm, scope_flags scope)
   {
     // statement ::=
-    //   block | nonblock-statement
+    //   statement-block | nonblock-statement
     const auto sentry = tstrm.copy_recursion_sentry();
 
-    if(auto qblock = do_accept_block_opt(tstrm, scope))
+    if(auto qblock = do_accept_statement_block_opt(tstrm, scope))
       return ::std::move(*qblock);
 
     if(auto qstmt = do_accept_nonblock_statement_opt(tstrm, scope))
@@ -1450,10 +1450,10 @@ opt<Statement::S_block>
 do_accept_statement_as_block_opt(Token_Stream& tstrm, scope_flags scope)
   {
     // statement ::=
-    //   block | nonblock-statement
+    //   statement-block | nonblock-statement
     const auto sentry = tstrm.copy_recursion_sentry();
 
-    auto qblock = do_accept_block_opt(tstrm, scope);
+    auto qblock = do_accept_statement_block_opt(tstrm, scope);
     if(qblock)
       return qblock;
 
@@ -1658,7 +1658,7 @@ do_accept_closure_function_no_name(cow_vector<Expression_Unit>& units, Token_Str
                 "[unmatched `(` at '$1']", op_sloc);
 
     op_sloc = tstrm.next_sloc();
-    auto qblock = do_accept_block_opt(tstrm, scope_flags_plain);
+    auto qblock = do_accept_statement_block_opt(tstrm, scope_flags_plain);
 
     if(!qblock) {
       // Try `equal-initializer`.
@@ -1698,7 +1698,7 @@ do_accept_closure_function(cow_vector<Expression_Unit>& units, Token_Stream& tst
     // closure-function ::=
     //   "func" "(" parameter-list ? ")" closure-body
     // closure-body ::=
-    //   block | equal-initializer | ref-initializer
+    //   statement-block | equal-initializer | ref-initializer
     auto sloc = tstrm.next_sloc();
     auto qkwrd = do_accept_keyword_opt(tstrm, { keyword_func });
     if(!qkwrd)

--- a/asteria/fwd.cpp
+++ b/asteria/fwd.cpp
@@ -359,6 +359,9 @@ describe_compiler_status(Compiler_Status status) noexcept
       case compiler_status_duplicate_name_in_parameter_list:
         return "duplicate name in parameter list";
 
+      case compiler_status_nondeclaration_statement_expected:
+        return "non-declaration statement expected";
+
       default:
         return "[unknown compiler status]";
     }

--- a/asteria/fwd.hpp
+++ b/asteria/fwd.hpp
@@ -802,6 +802,7 @@ enum Compiler_Status : uint32_t
     compiler_status_multiple_default                           = 2038,
     compiler_status_duplicate_name_in_structured_binding       = 2039,
     compiler_status_duplicate_name_in_parameter_list           = 2040,
+    compiler_status_nondeclaration_statement_expected          = 2041,
 
     // semantic errors
     compiler_status_undeclared_identifier                      = 3001,

--- a/doc/syntax.txt
+++ b/doc/syntax.txt
@@ -52,25 +52,22 @@ document ::=
 	statement *
 
 statement ::=
-	block | nonblock-statement
-
-block ::=
-	"{" statement * "}"
-
-nonblock-statement ::=
-	null-statement |
 	variable-definition | immutable-variable-definition | reference-definition |
-	function-definition | expression-statement |
-	if-statement | switch-statement | do-while-statement | while-statement | for-statement |
-	break-statement | continue-statement | throw-statement | return-statement |
-	assert-statement | try-statement | defer-statement
+	function-definition | defer-statement | null-statement |
+	nondeclaration-statement
 
 null-statement ::=
 	";"
 
+nondeclaration-statement ::=
+	if-statement | switch-statement | do-while-statement | while-statement |
+	for-statement | break-statement | continue-statement | throw-statement |
+	return-statement | assert-statement | try-statement | statement-block |
+	expression-statement
+
 variable-definition ::=
 	"var" variable-declarator equal-initailizer ? ( "," variable-declarator
-	equal-initializer ? ) ?  ";"
+	equal-initializer ? ) ? ";"
 
 variable-declarator ::=
 	identifier | structured-binding-array | structured-binding-object
@@ -92,34 +89,35 @@ reference-definition ::=
 	"ref" identifier ref-initailizer ( "," identifier ref-initializer ) ? ";"
 
 function-definition ::=
-	"func" identifier "(" parameter-list ? ")" block
+	"func" identifier "(" parameter-list ? ")" statement-block
 
 parameter-list ::=
 	"..." | identifier ( "," parameter-list ? ) ?
 
-expression-statement ::=
-	expression ";"
+statement-block ::=
+	"{" statement * "}"
+
+defer-statement ::=
+	"defer" expression ";"
 
 if-statement ::=
-	"if" negation ? "(" expression ")" statement ( "else" statement ) ?
+	"if" negation ? "(" expression ")" nondeclaration-statement ( "else"
+	nondeclaration-statement ) ?
 
 negation ::=
 	"!" | "not"
 
 switch-statement ::=
-	"switch" "(" expression ")" switch-block
-
-switch-block ::=
-	"{" swtich-clause * "}"
+	"switch" "(" expression ")" "{" swtich-clause * "}"
 
 switch-clause ::=
 	( "case" expression | "default" ) ":" statement *
 
 do-while-statement ::=
-	"do" statement "while" negation ? "(" expression ")" ";"
+	"do" nondeclaration-statement "while" negation ? "(" expression ")" ";"
 
 while-statement ::=
-	"while" negation ? "(" expression ")" statement
+	"while" negation ? "(" expression ")" nondeclaration-statement
 
 for-statement ::=
 	"for" "(" for-complement
@@ -128,13 +126,15 @@ for-complement ::=
 	for-complement-range | for-complement-triplet
 
 for-complement-range ::=
-	"each" identifier ( ( "," | ":" | "=" ) identifier ) ? "->" expression ")" statement
+	"each" identifier ( ( "," | ":" | "=" ) identifier ) ? "->" expression ")"
+	nondeclaration-statement
 
 for-complement-triplet ::=
-	for-initializer expression ? ";" expression ? ")" statement
+	for-initializer expression ? ";" expression ? ")" nondeclaration-statement
 
 for-initializer ::=
-	null-statement | variable-definition | immutable-variable-definition | expression-statement
+	null-statement | variable-definition | immutable-variable-definition |
+	expression-statement
 
 break-statement ::=
 	"break" break-target ? ";"
@@ -164,10 +164,11 @@ assert-statement ::=
 	"assert" expression ( ":" string-literal ) ? ";"
 
 try-statement ::=
-	"try" statement "catch" "(" identifier ")" statement
+	"try" nondeclaration-statement "catch" "(" identifier ")"
+	nondeclaration-statement
 
-defer-statement ::=
-	"defer" expression ";"
+expression-statement ::=
+	expression ";"
 
 expression ::=
 	infix-element infix-carriage *
@@ -183,9 +184,10 @@ prefix-operator ::=
 	"__iceil" | "__itrunc" | "__lzcnt" | "__tzcnt" | "__popcnt"
 
 primary-expression ::=
-	identifier | extern-identifier | literal | "this" | closure-function | unnamed-array |
-	unnamed-object | nested-expression | fused-multiply-add | prefix-binary-expression |
-	catch-expression | variadic-function-call | import-function-call
+	identifier | extern-identifier | literal | "this" | closure-function |
+	unnamed-array | unnamed-object | nested-expression | fused-multiply-add |
+	prefix-binary-expression |catch-expression | variadic-function-call |
+	import-function-call
 
 extern-identifier ::=
 	"extern" identifier
@@ -194,7 +196,7 @@ closure-function ::=
 	"func" "(" parameter-list ? ")" closure-body
 
 closure-body ::=
-	block | equal-initializer | ref-initializer
+	statement-block | equal-initializer | ref-initializer
 
 ref-initializer ::=
 	"->" expression
@@ -234,8 +236,8 @@ import-function-call ::=
 	"import" "(" argument-list ")"
 
 postfix-operator ::=
-	"++" | "--" | "[^]" | "[$]" | "[?]" |
-	postfix-operator | postfix-function-call | postfix-subscript | postfix-member-access
+	"++" | "--" | "[^]" | "[$]" | "[?]" | postfix-function-call |
+	postfix-subscript | postfix-member-access | postfix-operator
 
 postfix-function-call ::=
 	"(" argument-list ? ")"
@@ -253,8 +255,8 @@ infix-carriage ::=
 	infix-operator infix-element
 
 infix-operator ::=
-	infix-operator-ternary | infix-operator-logical-and | infix-operator-logical-or |
-	infix-operator-coalescence | infix-operator-general
+	infix-ternary | infix-logical-and | infix-logical-or | infix-coalescence |
+	infix-operator-general
 
 infix-operator-ternary ::=
 	( "?" | "?=" ) expression ":"
@@ -269,6 +271,7 @@ infix-operator-coalescence ::=
 	"??" | "??="
 
 infix-operator-general ::=
-	"+"  | "-"  | "*"  | "/"  | "%"  | "<<"  | ">>"  | "<<<"  | ">>>"  | "&"  | "|"  | "^"  |
-	"+=" | "-=" | "*=" | "/=" | "%=" | "<<=" | ">>=" | "<<<=" | ">>>=" | "&=" | "|=" | "^=" |
-	"="  | "==" | "!=" | "<"  | ">"  | "<="  | ">="  | "<=>"  | "</>"
+	"+" | "-" | "*" | "/" | "%" | "<<" | ">>" | "<<<" | ">>>" | "&" | "|" |
+	"^" | "+=" | "-=" | "*=" | "/=" | "%=" | "<<=" | ">>=" | "<<<=" | ">>>=" |
+	"&=" | "|=" | "^=" | "=" | "==" | "!=" | "<" | ">" | "<=" | ">=" | "<=>" |
+	"</>"

--- a/test/ref.cpp
+++ b/test/ref.cpp
@@ -26,8 +26,7 @@ int main()
         var f = func() = a;  // return by value
         try
           f() = 4;
-        catch(e)
-          ;
+        catch(e) { }
         assert a == 3;
 
         f = func() -> a;  // return by ref

--- a/test/switch_defer.cpp
+++ b/test/switch_defer.cpp
@@ -70,8 +70,7 @@ int main()
               defer str += '0a';
               defer str += '0b';
           }
-        catch(e)
-          ;
+        catch(e) { }
         assert str =='+1a';
 
         str = '+';
@@ -88,8 +87,7 @@ int main()
               throw 42;
               defer str += '0b';
           }
-        catch(e)
-          ;
+        catch(e) { }
         assert str == '+0a1b1a';
 
         str = '+';


### PR DESCRIPTION
Propose a change of
```text
statement ::=
       block | nonblock-statement

block ::=
       "{" statement * "}"

nonblock-statement ::=
       null-statement |
       variable-definition | immutable-variable-definition | reference-definition |
       function-definition | expression-statement |
       if-statement | switch-statement | do-while-statement | while-statement | for-statement |
       break-statement | continue-statement | throw-statement | return-statement |
       assert-statement | try-statement | defer-statement
```
to
```text
statement ::=
       function-definition | defer-statement | null-statement |
       nondeclaration-statement

nondeclaration-statement ::=
       if-statement | switch-statement | do-while-statement | while-statement |
       for-statement | break-statement | continue-statement | throw-statement |
       return-statement | assert-statement | try-statement | statement-block |
       expression-statement
```

The intent is to disallow obvious erroneous construction syntactically, such as 
```go
if(condition);
  do_something();
```
or
```go
while(condition)
  var a = foo();
  do_something_else_with(a);
```

